### PR TITLE
Backport fix for dedicated windows

### DIFF
--- a/persp-mode.el
+++ b/persp-mode.el
@@ -1368,11 +1368,13 @@ Return `NAME'."
               (if pwc
                   (let ((persp-add-on-switch-or-display nil))
                     (delete-other-windows)
+                    (set-window-dedicated-p nil nil)
                     (funcall persp-window-state-put-function pwc frame)
                     (when (and new-frame persp-is-ibc-as-f-supported)
                       (setq initial-buffer-choice #'(lambda () persp-special-last-buffer))))
                 (when persp-reset-windows-on-nil-window-conf
                   (delete-other-windows)
+                  (set-window-dedicated-p nil nil)
                   (persp-revive-scratch persp t)))))
           (when gr-mode
             (golden-ratio-mode 1)))))))


### PR DESCRIPTION
When switching from a perspective that has a dedicated window, sometimes the window configuration of the old or new perspective becomes messed up. Neotree, for example, uses a dedicated window and triggers this bug.
This is a backport of https://github.com/Bad-ptr/persp-mode.el/commit/c6074ce3b61aca3e1ca1104ef5a751028357badf and https://github.com/Bad-ptr/persp-mode.el/commit/bf36bf8811a5b2a8f828e22ad387ed8368c94965.
